### PR TITLE
Fix build failure on rustc 1.42.0-nightly (8417d68de 2020-02-03)

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 use self::BucketState::*;
-use std::alloc::{handle_alloc_error, Alloc, Global, Layout, LayoutErr};
+use std::alloc::{handle_alloc_error, AllocRef, Global, Layout, LayoutErr};
 use std::collections::TryReserveError;
 use std::marker;
 use std::mem::{needs_drop, size_of};


### PR DESCRIPTION
Hi

Currently https://github.com/PSeitz/veloci build fails due to this crate's build failing as https://github.com/rust-lang/wg-allocators/issues/8 being has been merged into nightly rustc.

```
~/git/rs/rust_string_hashmap [master] »  cargo build                                                                                                                                                                    [15:07:56]
   Compiling term_hashmap v0.1.0 (/Users/i077570/git/sap-rs/rust_string_hashmap)
error[E0432]: unresolved import `std::alloc::Alloc`
  --> src/table.rs:12:38
   |
12 | use std::alloc::{handle_alloc_error, Alloc, Global, Layout, LayoutErr};
   |                                      ^^^^^
   |                                      |
   |                                      no `Alloc` in `alloc`
   |                                      help: a similar name exists in the module: `alloc`

warning: unused `#[macro_use]` import
  --> src/lib.rs:30:1
   |
30 | #[macro_use]
   | ^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unnecessary parentheses around type
    --> src/lib.rs:1332:34
     |
1332 |     fn next(&mut self) -> Option<(u32)> {
     |                                  ^^^^^ help: remove these parentheses
     |
     = note: `#[warn(unused_parens)]` on by default

warning: unnecessary parentheses around type
    --> src/lib.rs:1395:34
     |
1395 |     fn next(&mut self) -> Option<(&'a str)> {
     |                                  ^^^^^^^^^ help: remove these parentheses

warning: unnecessary parentheses around type
    --> src/lib.rs:1749:34
     |
1749 |     fn next(&mut self) -> Option<(&'a V)> {
     |                                  ^^^^^^^ help: remove these parentheses

warning: unnecessary parentheses around type
    --> src/lib.rs:1769:34
     |
1769 |     fn next(&mut self) -> Option<(&'a mut V)> {
     |                                  ^^^^^^^^^^^ help: remove these parentheses

error[E0599]: no method named `alloc` found for struct `std::alloc::Global` in the current scope
   --> src/table.rs:618:29
    |
618 |         let buffer = Global.alloc(layout).map_err(|e| match fallibility {
    |                             ^^^^^ method not found in `std::alloc::Global`
    |
    = help: items from traits can only be used if the trait is in scope
    = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
            `use std::alloc::AllocRef;`

error[E0599]: no method named `dealloc` found for struct `std::alloc::Global` in the current scope
    --> src/table.rs:1007:20
     |
1007 |             Global.dealloc(NonNull::new_unchecked(self.hashes.ptr()).cast(), layout);
     |                    ^^^^^^^ method not found in `std::alloc::Global`
     |
     = help: items from traits can only be used if the trait is in scope
     = note: the following trait is implemented but not in scope; perhaps add a `use` for it:
             `use std::alloc::AllocRef;`

error: aborting due to 3 previous errors

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `term_hashmap`.
```
Please let me know if this is the right way to fix the issue

Regards
Delta